### PR TITLE
Use custom Pull RPC for Google Pub Sub for custom control

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20181003184128-c57b0facaced // indirect
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	google.golang.org/api v0.0.0-20181016000437-c51f30376ab7 // indirect
-	google.golang.org/genproto v0.0.0-20181004005441-af9cb2a35e7f // indirect
+	google.golang.org/genproto v0.0.0-20181004005441-af9cb2a35e7f
 	google.golang.org/grpc v1.24.0
 )
 

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -261,6 +261,10 @@ func (g *GoogleCloud) subscribe(opts ps.HandlerOptions, h ps.MsgHandler, ready c
 			g.subs[subName] = cancel
 			mutex.Unlock()
 
+			if opts.Concurrency == 0 {
+				opts.Concurrency = 10
+			}
+
 			req := &pbpb.PullRequest{
 				Subscription: fmt.Sprintf("projects/%s/subscriptions/%s", g.projectID, subName),
 				MaxMessages:  int32(math.Floor(float64(opts.Concurrency) * 1.2)),

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -2,16 +2,21 @@ package google
 
 import (
 	"context"
+	fmt "fmt"
+	math "math"
 	"sync"
 	"time"
 
 	"cloud.google.com/go/pubsub"
+	pbs "cloud.google.com/go/pubsub/apiv1"
 	"github.com/dropbox/godropbox/errors"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/jpillora/backoff"
 	"github.com/lileio/logr"
 	ps "github.com/lileio/pubsub/v2"
 	"github.com/segmentio/ksuid"
 	"golang.org/x/sync/semaphore"
+	pbpb "google.golang.org/genproto/googleapis/pubsub/v1"
 
 	"github.com/sirupsen/logrus"
 )
@@ -22,9 +27,14 @@ var (
 
 // GoogleCloud provides google cloud pubsub
 type GoogleCloud struct {
-	client   *pubsub.Client
-	topics   map[string]*pubsub.Topic
-	subs     map[string]context.CancelFunc
+	client    *pubsub.Client
+	subClient *pbs.SubscriberClient
+
+	projectID string
+
+	topics map[string]*pubsub.Topic
+	subs   map[string]context.CancelFunc
+
 	shutdown bool
 }
 
@@ -35,10 +45,17 @@ func NewGoogleCloud(projectID string) (*GoogleCloud, error) {
 		return nil, err
 	}
 
+	s, err := pbs.NewSubscriberClient(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
 	return &GoogleCloud{
-		client: c,
-		topics: map[string]*pubsub.Topic{},
-		subs:   map[string]context.CancelFunc{},
+		projectID: projectID,
+		client:    c,
+		subClient: s,
+		topics:    map[string]*pubsub.Topic{},
+		subs:      map[string]context.CancelFunc{},
 	}, nil
 }
 
@@ -84,7 +101,6 @@ func (g *GoogleCloud) Shutdown() {
 		}(v)
 	}
 	wg.Wait()
-	return
 }
 
 func (g *GoogleCloud) subscribe(opts ps.HandlerOptions, h ps.MsgHandler, ready chan<- bool) {
@@ -112,13 +128,20 @@ func (g *GoogleCloud) subscribe(opts ps.HandlerOptions, h ps.MsgHandler, ready c
 				Topic:       t,
 				AckDeadline: opts.Deadline,
 			}
-			sub, err = g.client.CreateSubscription(context.Background(), subName, sc)
+			_, err = g.client.CreateSubscription(context.Background(), subName, sc)
 			if err != nil {
 				logrus.Panicf("Can't subscribe to topic: %s", err.Error())
 			}
+		} else {
+			_, err = sub.Update(context.Background(), pubsub.SubscriptionConfigToUpdate{
+				AckDeadline: opts.Deadline,
+			})
+			if err != nil {
+				logrus.Panicf("Can't update: %s", err.Error())
+			}
 		}
 
-		logrus.Infof("Subscribed to topic %s with name %s", opts.Topic, subName)
+		logrus.Infof("Subscribing to topic %s with name %s", opts.Topic, subName)
 		ready <- true
 
 		b := &backoff.Backoff{
@@ -129,10 +152,17 @@ func (g *GoogleCloud) subscribe(opts ps.HandlerOptions, h ps.MsgHandler, ready c
 			Jitter: true,
 		}
 
+		type WorkerMsg struct {
+			ackID string
+			m     *pbpb.PubsubMessage
+			ctx   context.Context
+		}
+
 		// create a semaphore, this is because Google PubSub will spam
 		// your service if you can't process a message
 		// and will also not handle
 		sem := semaphore.NewWeighted(int64(opts.Concurrency))
+		pool := make(chan *WorkerMsg)
 
 		// Listen to messages and call the MsgHandler
 		for {
@@ -150,51 +180,117 @@ func (g *GoogleCloud) subscribe(opts ps.HandlerOptions, h ps.MsgHandler, ready c
 				break
 			}
 
-			cctx, cancel := context.WithCancel(context.Background())
-			err = sub.Receive(cctx, func(ctx context.Context, m *pubsub.Message) {
+			for w := range pool {
+				ctx, c := context.WithTimeout(w.ctx, opts.Deadline)
 				if serr := sem.Acquire(ctx, 1); serr != nil {
 					logrus.Errorf(
 						"pubsub: Failed to acquire worker semaphore: %v",
 						serr,
 					)
-					return
-				}
-				defer sem.Release(1)
-
-				b.Reset()
-				msg := ps.Msg{
-					ID:          m.ID,
-					Metadata:    m.Attributes,
-					Data:        m.Data,
-					PublishTime: &m.PublishTime,
-					Ack: func() {
-						m.Ack()
-					},
-					Nack: func() {
-						m.Nack()
-					},
+					c()
+					continue
 				}
 
-				err = h(ctx, msg)
-				if err != nil {
-					return
-				}
+				go func(w *WorkerMsg, c context.CancelFunc) {
+					defer sem.Release(1)
+					defer c()
 
-				if opts.AutoAck {
-					m.Ack()
-				}
-			})
+					m := w.m
 
+					pt, _ := ptypes.Timestamp(m.PublishTime)
+
+					msg := ps.Msg{
+						ID:          m.MessageId,
+						Metadata:    m.Attributes,
+						Data:        m.Data,
+						PublishTime: &pt,
+						Ack: func() {
+							req := &pbpb.AcknowledgeRequest{
+								Subscription: "projects/" + g.projectID + "/subscriptions/" + subName,
+								AckIds:       []string{w.ackID},
+							}
+
+							err := g.subClient.Acknowledge(context.Background(), req)
+							if err != nil {
+								logrus.Errorf(
+									"Failed to Ack %s on sub %v. Err: %v",
+									w.ackID, subName, err,
+								)
+							}
+						},
+						Nack: func() {
+							req := &pbpb.ModifyAckDeadlineRequest{
+								Subscription:       "projects/" + g.projectID + "/subscriptions/" + subName,
+								AckIds:             []string{w.ackID},
+								AckDeadlineSeconds: 300,
+							}
+
+							err := g.subClient.ModifyAckDeadline(context.Background(), req)
+							if err != nil {
+								logrus.Errorf(
+									"Failed to modify deadline %s on sub %v. Err: %v",
+									w.ackID, subName, err,
+								)
+							}
+						},
+					}
+
+					err = h(ctx, msg)
+					if err != nil {
+						msg.Nack()
+						return
+					}
+
+					if opts.AutoAck {
+						msg.Ack()
+					}
+				}(w, c)
+
+			}
+		}
+
+		// Listen to messages and call the MsgHandler
+		for {
+			if g.shutdown {
+				close(pool)
+				break
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			mutex.Lock()
+			g.subs[subName] = cancel
+			mutex.Unlock()
+
+			req := &pbpb.PullRequest{
+				Subscription: fmt.Sprintf("projects/%s/subscriptions/%s", g.projectID, subName),
+				MaxMessages:  int32(math.Floor(float64(opts.Concurrency) * 1.2)),
+			}
+
+			res, err := g.subClient.Pull(ctx, req)
 			if err != nil {
 				d := b.Duration()
 				logrus.Errorf(
-					"Subscription receive to topic %s failed, reconnecting in %v. Err: %v",
+					"Subscription pull from topic %s failed, retrying in %v. Err: %v",
 					opts.Topic, d, err,
 				)
 				time.Sleep(d)
+				_ = cancel
+				continue
 			}
 
-			g.subs[subName] = cancel
+			if len(res.ReceivedMessages) == 0 {
+				time.Sleep(1 * time.Second)
+				_ = cancel
+				continue
+			}
+
+			for _, m := range res.ReceivedMessages {
+				pool <- &WorkerMsg{
+					m:     m.Message,
+					ackID: m.AckId,
+					ctx:   ctx,
+				}
+			}
 		}
 	}()
 }


### PR DESCRIPTION
A concept PR to show how we might have better flow control over pulling messages.

This should keep pulling as many as you can process, making ETL flushing work better for an example